### PR TITLE
feat: Enhance date handling and command runner options in validation …

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -14,5 +14,6 @@ vars:
   # audit_helper__database: audit_helper
   # audit_helper__schema: log
   # audit_helper__date_of_process: 2024-09-09 # default to UTC now if not specified
+  # audit_helper__allowed_date_of_processes: ['2024-09-09', '2024-09-10']
   # audit_helper__source_database: ???
   # audit_helper__source_schema: ???

--- a/macros/dwh/clone_relation.sql
+++ b/macros/dwh/clone_relation.sql
@@ -1,18 +1,24 @@
-{% macro clone_relation(identifier, source_database=none, source_schema=none) %}
+{% macro clone_relation(identifier, source_database=none, source_schema=none, use_prev=false) %}
     {{ return(adapter.dispatch('clone_relation', 'audit_helper_ext')(
         identifier=identifier,
         source_database=source_database,
-        source_schema=source_schema
+        source_schema=source_schema,
+        use_prev=use_prev
     )) }}
 {% endmacro %}
 
 
-{% macro default__clone_relation(identifier, source_database, source_schema) %}
+{% macro default__clone_relation(identifier, source_database, source_schema, use_prev) %}
     {% set copy_mode = 'clone' %}
 
     {# get source location #}
     {% set source_database = source_database or target.database %}
-    {% set source_schema = source_schema or audit_helper_ext.get_versioned_name(name=var('audit_helper__source_schema', target.schema)) %}
+    {% set source_schema = source_schema 
+                            or audit_helper_ext.get_versioned_name(
+                                    name=var('audit_helper__source_schema', target.schema),
+                                    use_prev=use_prev
+                                )
+    %}
 
     {# checking source table #}
     {% set source_relation_exists, source_relation, _ = audit_helper_ext.get_relation(

--- a/macros/utility/date_of_process.sql
+++ b/macros/utility/date_of_process.sql
@@ -16,7 +16,7 @@
   {% set allowed_dates = var('audit_helper__allowed_date_of_processes', []) | list %}
   {% if allowed_dates and date_str not in allowed_dates %}
     {{ exceptions.raise_compiler_error(
-      "Invalid `audit_helper__allowed_date_of_processes`.
+      "❌ Invalid `audit_helper__allowed_date_of_processes`.
       Expected `audit_helper__date_of_process` in " ~ allowed_dates ~ ", but got: " ~ date_str
     ) }}
   {% endif %}

--- a/macros/utility/date_of_process.sql
+++ b/macros/utility/date_of_process.sql
@@ -1,21 +1,44 @@
-{% macro date_of_process(format=false) %}
-  {{ return(adapter.dispatch('date_of_process', 'audit_helper_ext')(format=format)) }}
+{% macro date_of_process(format=false, use_prev=false) %}
+  {{ return(adapter.dispatch('date_of_process', 'audit_helper_ext')(format=format, use_prev=use_prev)) }}
 {% endmacro %}
 
 
-{% macro default__date_of_process(format) %}
+{% macro default__date_of_process(format, use_prev) %}
 
   {% set dt = modules.datetime.datetime %}
+  {% set re = modules.re %}
 
   {% set date_str = var('audit_helper__date_of_process', '') | string %}
   {% if not date_str %}
     {% set date_str = dt.utcnow().strftime('%Y-%m-%d') %}
   {% endif %}
 
-  {% if not format %}
-    {{ return(date_str) }}
+  {% set allowed_dates = var('audit_helper__allowed_date_of_processes', []) | list %}
+  {% if allowed_dates and date_str not in allowed_dates %}
+    {{ exceptions.raise_compiler_error(
+      "Invalid `audit_helper__allowed_date_of_processes`.
+      Expected `audit_helper__date_of_process` in " ~ allowed_dates ~ ", but got: " ~ date_str
+    ) }}
   {% endif %}
 
-  {{ return(dt.strptime(date_str, "%Y-%m-%d").strftime('%Y%m%d')) }}
+  {% if use_prev %}
+    {% set prev_index = allowed_dates.index(date_str) -1 %}
+    {% if prev_index >= 0 %}
+      {% set date_str = allowed_dates[prev_index] %}
+      {{ log("📆 Looking at previous date: " ~ date_str, info=True) if execute }}
+    {% else %}
+      {% do exceptions.warn(
+        "⚠️  Cannot find previous date for '" ~ date_str 
+          ~ "' in `audit_helper__allowed_date_of_processes`. Using current one!"
+      ) %}
+    {% endif %}
+    
+  {% endif %}
+
+  {% if format and re.match('^\\d{4}-\\d{2}-\\d{2}$', date_str) %}
+    {% set date_str = dt.strptime(date_str, "%Y-%m-%d").strftime('%Y%m%d') | string %}
+  {% endif %}
+
+  {{ return(date_str) }}
 
 {% endmacro %}

--- a/macros/utility/date_of_process.sql
+++ b/macros/utility/date_of_process.sql
@@ -22,16 +22,16 @@
   {% endif %}
 
   {% if use_prev %}
-    {% set prev_index = allowed_dates.index(date_str) -1 %}
-    {% if prev_index >= 0 %}
-      {% set date_str = allowed_dates[prev_index] %}
-      {{ log("📆 Looking at previous date: " ~ date_str, info=True) if execute }}
-    {% else %}
-      {% do exceptions.warn(
-        "⚠️  Cannot find previous date for '" ~ date_str 
-          ~ "' in `audit_helper__allowed_date_of_processes`. Using current one!"
-      ) %}
+    {% set prev_index = allowed_dates.index(date_str) - 1 %}
+    {% if not prev_index or prev_index < 0 %}
+      {{ exceptions.raise_compiler_error(
+        "❌ Cannot find previous date for '" ~ date_str 
+          ~ "' in `audit_helper__allowed_date_of_processes` = " ~ allowed_dates
+      ) }}
     {% endif %}
+
+    {% set date_str = allowed_dates[prev_index] %}
+    {{ log("📆 Looking at previous date: " ~ date_str, info=True) if execute }}
     
   {% endif %}
 

--- a/macros/utility/date_of_process.yml
+++ b/macros/utility/date_of_process.yml
@@ -1,10 +1,51 @@
 macros:
   - name: date_of_process
     description: |
-      Returns the source's snapshot date(time) which is configured by `audit_helper__date_of_process` variable.
+      Returns the source's snapshot date which is configured by the `audit_helper__date_of_process` variable.
+      Either it is YYYY-MM-DD or free text e.g. Day1, Day2
 
-      If not available, it uses the UTC now value
+      This macro provides a centralized way to handle date references across your audit helper operations,
+      making it easier to maintain consistent date logic throughout your dbt project.
+
+      **Behavior:**
+      - If `audit_helper__date_of_process` variable is set, uses that value
+      - If not available, defaults to current UTC date in YYYY-MM-DD format
+      - Validates the date against `audit_helper__allowed_date_of_processes` if configured
+      - Supports getting the previous date from the allowed dates list when `use_prev=true`
+      - Supports optional formatting to convert YYYY-MM-DD to YYYYMMDD format
+
+      **Variable Configuration:**
+      Set in your dbt_project.yml or profiles.yml:
+      ```yaml
+      vars:
+        audit_helper__date_of_process: "2024-01-15"
+        # audit_helper__date_of_process: "Day1"
+
+        # Optional: Define allowed dates for validation and previous date lookup
+        audit_helper__allowed_date_of_processes:
+          - "2024-01-10"
+          - "2024-01-15"
+          - "2024-01-20"
+          # - "Day1"
+          # - "Day2"
+          # - "Day3"
+      ```
+
+      **Validation & Previous Date Logic:**
+      - If `audit_helper__allowed_date_of_processes` is set, the current date must be in this list
+      - When `use_prev=true`, returns the previous date from the allowed dates list
+      - If no previous date exists, warns and uses the current date
     arguments:
       - name: format
         type: boolean
-        description: Turn it to `true` to format the date string to YYYYMMDD
+        description: |
+          When set to `true`, converts date from YYYY-MM-DD format to YYYYMMDD format.
+          Only applies when the date matches the YYYY-MM-DD pattern.
+          Defaults to `false`.
+      - name: use_prev
+        type: boolean
+        description: |
+          When set to `true`, returns the previous date from the `audit_helper__allowed_date_of_processes` list.
+          Requires `audit_helper__allowed_date_of_processes` to be configured.
+          If no previous date exists, warns and uses the current date.
+          Defaults to `false`.

--- a/macros/utility/get_versioned_name.sql
+++ b/macros/utility/get_versioned_name.sql
@@ -1,11 +1,11 @@
-{% macro get_versioned_name(name) %}
-  {{ return(adapter.dispatch('get_versioned_name', 'audit_helper_ext')(name=name)) }}
+{% macro get_versioned_name(name, use_prev=false) %}
+  {{ return(adapter.dispatch('get_versioned_name', 'audit_helper_ext')(name=name, use_prev=use_prev)) }}
 {% endmacro %}
 
 
-{% macro default__get_versioned_name(name) %}
+{% macro default__get_versioned_name(name, use_prev) %}
 
-    {% set yyyymmdd = audit_helper_ext.date_of_process(format=true) %}
+    {% set yyyymmdd = audit_helper_ext.date_of_process(format=true, use_prev=use_prev) %}
     {{ return(name ~ "__" ~ yyyymmdd) }}
 
 {% endmacro %}

--- a/scripts/validation__all.sh
+++ b/scripts/validation__all.sh
@@ -32,6 +32,9 @@ OPTIONS:
     -p DATE     Audit helper date of process (e.g., "2024-01-01")
                 When specified, triggers clone operations from legacy data
                 When empty/omitted, skips cloning and runs with full-refresh
+    -c RUNNER   Command runner to use (default: poetry)
+                  poetry   - Use 'poetry run' for commands
+                  uv       - Use 'uv run' for commands
     -r          Skip model runs, validate only
                 Useful when models are already built and you only want validation
     -v          Run models only, skip validation
@@ -40,31 +43,36 @@ OPTIONS:
 EXAMPLES:
     # Run all validations with default settings
     $0
-    
+
     # Run specific validation types
     $0 -t count                                # Count validation only
     $0 -t all_row                              # Row-by-row validation
     $0 -t upstream_row_count                   # Get source row counts
-    
+
     # Target different model directories
     $0 -d models/02_intermediate               # Validate intermediate models
     $0 -d models/01_staging                    # Validate staging models
-    
+
     # Single model validation
     $0 -m exp_fsr_rol_plyr_anchr_id           # All validations for one model
     $0 -m exp_fsr_rol_plyr_anchr_id -t count  # Count validation for one model
     $0 -m exp_fsr_rol_plyr_anchr_id -r        # Skip runs, validate one model only
-    
+
+    # Use with different command runners
+    $0 -c poetry                              # Explicitly use poetry run (default)
+    $0 -c uv -t count                         # Use uv run instead of poetry run
+
     # Use with audit date (triggers clone operations)
     $0 -p "2024-01-01"                        # Clone from specific date
     $0 -p "2024-01-01" -t count               # Clone + count validation
-    
+
     # Skip operations for faster execution
     $0 -t count -r                            # Count validation only, skip model runs
     $0 -v                                     # Build models only, skip validation
-    
+
     # Complex combinations
     $0 -d models/03_mart -t all_row -p "2024-01-01" -r   # Row validation with clone, skip runs
+    $0 -c poetry -d models/03_mart -t count   # Use poetry run for count validation
 
 VALIDATION TYPES:
     count               Fast row count comparison between models and legacy data
@@ -124,12 +132,22 @@ log_operation() {
 # Validation functions
 validate_dependencies() {
     local missing_deps=()
-    
-    # Check for required commands
-    command -v poetry >/dev/null 2>&1 || missing_deps+=("poetry")
+
+    # Check for the configured command runner
+    if [[ "$COMMAND_RUNNER" == "poetry" ]]; then
+        command -v poetry >/dev/null 2>&1 || missing_deps+=("poetry")
+    elif [[ "$COMMAND_RUNNER" == "uv" ]]; then
+        command -v uv >/dev/null 2>&1 || missing_deps+=("uv")
+    else
+        log_error "Invalid command runner: $COMMAND_RUNNER"
+        log_error "Valid options: uv, poetry"
+        exit 1
+    fi
+
+    # Check for other required commands
     command -v find >/dev/null 2>&1 || missing_deps+=("find")
     command -v sort >/dev/null 2>&1 || missing_deps+=("sort")
-    
+
     if [[ ${#missing_deps[@]} -gt 0 ]]; then
         log_error "Missing required dependencies: ${missing_deps[*]}"
         log_error "Please install missing dependencies and try again."
@@ -203,11 +221,21 @@ run_operation_for_all_models() {
         # Run the operation and capture output to model-specific log (append mode)
         {
             if [[ -n "$cmd_args" && "$cmd_args" != "" ]]; then
-                log_operation "Executing: poetry run dbt run-operation $macro_call --args '$cmd_args'"
-                poetry run dbt run-operation "$macro_call" --args "$cmd_args"
+                if [[ -n "$DATE_OF_PROCESS" && "$DATE_OF_PROCESS" != "" ]]; then
+                    log_operation "Executing: $RUN_CMD dbt run-operation $macro_call --args '$cmd_args' ($DATE_OF_PROCESS)"
+                    $RUN_CMD dbt run-operation "$macro_call" --args "$cmd_args" --vars "{'audit_helper__date_of_process': '$DATE_OF_PROCESS'}"
+                else
+                    log_operation "Executing: $RUN_CMD dbt run-operation $macro_call --args '$cmd_args'"
+                    $RUN_CMD dbt run-operation "$macro_call" --args "$cmd_args"
+                fi
             else
-                log_operation "Executing: poetry run dbt run-operation $macro_call"
-                poetry run dbt run-operation "$macro_call"
+                if [[ -n "$DATE_OF_PROCESS" && "$DATE_OF_PROCESS" != "" ]]; then
+                    log_operation "Executing: $RUN_CMD dbt run-operation $macro_call ($DATE_OF_PROCESS)"
+                    $RUN_CMD dbt run-operation "$macro_call" --vars "{'audit_helper__date_of_process': '$DATE_OF_PROCESS'}"
+                else
+                    log_operation "Executing: $RUN_CMD dbt run-operation $macro_call"
+                    $RUN_CMD dbt run-operation "$macro_call"
+                fi
             fi
             
             local exit_code=$?
@@ -226,42 +254,51 @@ run_operation_for_all_models() {
 # Function to run clone operations for models
 run_clone_for_all_models() {
     if [[ -n "$SINGLE_MODEL" ]]; then
-        log_info "🐑  Clone relation for single model: $SINGLE_MODEL from data version = $DATE_OF_PROCESS"
+        log_info "🐑  Clone relation for single model: $SINGLE_MODEL from PREVIOUS data version of $DATE_OF_PROCESS"
         log_operation "🐑  Cloning: $SINGLE_MODEL"
-        poetry run dbt run-operation clone_relation --args "{'identifier': '$SINGLE_MODEL'}" || log_error "Clone failed for $SINGLE_MODEL"
+        uv run dbt run-operation clone_relation --args "{'identifier': '$SINGLE_MODEL', 'use_prev': true}" --vars "{'audit_helper__date_of_process': '$DATE_OF_PROCESS'}" || log_error "Clone failed for $SINGLE_MODEL"
     else
-        log_info "🐑  Clone all relations from data version = $DATE_OF_PROCESS"
+        log_info "🐑  Clone all relations from PREVIOUS data version of $DATE_OF_PROCESS"
         for model in "${MODELS[@]}"; do
             log_operation "🐑  Cloning: $model"
-            poetry run dbt run-operation clone_relation --args "{'identifier': '$model'}" || log_error "Clone failed for $model, continuing..."
+            uv run dbt run-operation clone_relation --args "{'identifier': '$model', 'use_prev': true}" --vars "{'audit_helper__date_of_process': '$DATE_OF_PROCESS'}" || log_error "Clone failed for $model, continuing..."
         done
     fi
 }
 
 # Parse command-line options
-while getopts ht:d:m:p:vr flag; do
+while getopts ht:d:m:p:c:vr flag; do
     case "${flag}" in
         h) show_help; exit 0;;
         t) VALIDATION_TYPE=${OPTARG};;
         d) MART_DIR=${OPTARG};;
         m) SINGLE_MODEL=${OPTARG};;
         p) DATE_OF_PROCESS=${OPTARG};;
+        c) COMMAND_RUNNER=${OPTARG};;
         r) SKIP_RUN=true;;
         v) SKIP_VALIDATION=true;;
         ?) echo "Use -h for help" >&2; exit 1;;
     esac
 done
 
-# Validate dependencies first
-validate_dependencies
-
-# Set defaults and validate
+# Set defaults
 VALIDATION_TYPE="${VALIDATION_TYPE:-all}"
 MART_DIR="${MART_DIR:-models/03_mart}"
 SINGLE_MODEL="${SINGLE_MODEL:-}"
 DATE_OF_PROCESS="${DATE_OF_PROCESS:-}"
+COMMAND_RUNNER="${COMMAND_RUNNER:-poetry}"
 SKIP_RUN="${SKIP_RUN:-false}"
 SKIP_VALIDATION="${SKIP_VALIDATION:-false}"
+
+# Set the run command based on the runner
+if [[ "$COMMAND_RUNNER" == "poetry" ]]; then
+    RUN_CMD="poetry run"
+else
+    RUN_CMD="uv run"
+fi
+
+# Validate dependencies after setting COMMAND_RUNNER
+validate_dependencies
 
 # Validate configuration
 validate_validation_type "$VALIDATION_TYPE"
@@ -338,13 +375,13 @@ if [[ "$SKIP_RUN" != "true" ]]; then
             log_header "▶️  Run single model: $SINGLE_MODEL (with full-refresh)"
             echo ""
             set -x #echo on
-            poetry run dbt run -s +"$SINGLE_MODEL" --full-refresh
+            $RUN_CMD dbt run -s +"$SINGLE_MODEL" --full-refresh
             set +x #echo off
         else
             log_header "▶️  Run all models (with full-refresh)"
             echo ""
             set -x #echo on
-            poetry run dbt run -s +"$MART_DIR/" --full-refresh
+            $RUN_CMD dbt run -s +"$MART_DIR/" --full-refresh
             set +x #echo off
         fi
     else
@@ -357,13 +394,13 @@ if [[ "$SKIP_RUN" != "true" ]]; then
             log_header "▶️  Run single model: $SINGLE_MODEL (without full-refresh)"
             echo ""
             set -x #echo on
-            poetry run dbt run -s +"$SINGLE_MODEL"
+            $RUN_CMD dbt run -s +"$SINGLE_MODEL" --vars "{'audit_helper__date_of_process': '$DATE_OF_PROCESS'}"
             set +x #echo off
         else
             log_header "▶️  Run all models (without full-refresh)"
             echo ""
             set -x #echo on
-            poetry run dbt run -s +"$MART_DIR/"
+            $RUN_CMD dbt run -s +"$MART_DIR/" --vars "{'audit_helper__date_of_process': '$DATE_OF_PROCESS'}"
             set +x #echo off
         fi
     fi

--- a/scripts/validation__all.sh
+++ b/scripts/validation__all.sh
@@ -256,12 +256,18 @@ run_clone_for_all_models() {
     if [[ -n "$SINGLE_MODEL" ]]; then
         log_info "🐑  Clone relation for single model: $SINGLE_MODEL from PREVIOUS data version of $DATE_OF_PROCESS"
         log_operation "🐑  Cloning: $SINGLE_MODEL"
-        uv run dbt run-operation clone_relation --args "{'identifier': '$SINGLE_MODEL', 'use_prev': true}" --vars "{'audit_helper__date_of_process': '$DATE_OF_PROCESS'}" || log_error "Clone failed for $SINGLE_MODEL"
+        
+        set -x #echo on
+        $RUN_CMD dbt run-operation clone_relation --args "{'identifier': '$SINGLE_MODEL', 'use_prev': true}" --vars "{'audit_helper__date_of_process': '$DATE_OF_PROCESS'}" || log_error "Clone failed for $SINGLE_MODEL"
+        set +x #echo off
     else
         log_info "🐑  Clone all relations from PREVIOUS data version of $DATE_OF_PROCESS"
         for model in "${MODELS[@]}"; do
             log_operation "🐑  Cloning: $model"
-            uv run dbt run-operation clone_relation --args "{'identifier': '$model', 'use_prev': true}" --vars "{'audit_helper__date_of_process': '$DATE_OF_PROCESS'}" || log_error "Clone failed for $model, continuing..."
+
+            set -x #echo on
+            $RUN_CMD dbt run-operation clone_relation --args "{'identifier': '$model', 'use_prev': true}" --vars "{'audit_helper__date_of_process': '$DATE_OF_PROCESS'}" || log_error "Clone failed for $model, continuing..."
+            set +x #echo off
         done
     fi
 }


### PR DESCRIPTION
- Added support for allowed date validation in date_of_process macro.

Old config:
```yml
vars:
  audit_helper__date_of_process: day1
```

New config: helps to easily identify the previous date value (supporting free text date value)
```yml
vars:
  audit_helper__date_of_process: day1
  audit_helper__allowed_date_of_processes: ['day1', 'day2']
```

- Updated `clone_relation` and `get_versioned_name` macros to accept `use_prev` parameter.
- Improved `date_of_process` macro documentation and behavior with `use_prev` parameter
- Enhanced validation script to allow selection of command runner (poetry or uv).

`poetry` users (default):
```bash
dbt_packages/audit_helper_ext/scripts/validation__all.sh -m <model> [-c poetry]
```

`uv` users:
```bash
dbt_packages/audit_helper_ext/scripts/validation__all.sh -m <model> -c uv
```

sh helper:
```bash
dbt_packages/audit_helper_ext/scripts/validation__all.sh -h
```

This is a:

- [x] house-keeping work

## Checklist

- [x] This code is associated with an Issue which has been triaged and accepted for development
- [x] I have verified that these changes work locally on the following warehouses:
  - [x] Snowflake
  - [ ] BigQuery
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
