### PR TITLE
fix: default schema insight query

### DIFF
--- a/macros/utility/filter_validation_result/filter_schema_validation.sql
+++ b/macros/utility/filter_validation_result/filter_schema_validation.sql
@@ -1,12 +1,7 @@
 {% macro filter_schema_validation_mismatch_data_type(row) %}
-  {% set has_data_type_match = audit_helper_ext.get_actual_column_name(row, 'HAS_DATA_TYPE_MATCH') %}
-  {% set in_both = audit_helper_ext.get_actual_column_name(row, 'IN_BOTH') %}
-  {{ return(not has_data_type_match and in_both) }}
+  {{ return(not row['HAS_DATA_TYPE_MATCH'] and row["IN_BOTH"]) }}
 {% endmacro %}
 
 {% macro filter_schema_validation_errors(row) %}
-  {% set has_data_type_match = audit_helper_ext.get_actual_column_name(row, 'HAS_DATA_TYPE_MATCH') %}
-  {% set in_a_only = audit_helper_ext.get_actual_column_name(row, 'IN_A_ONLY') %}
-  {% set in_b_only = audit_helper_ext.get_actual_column_name(row, 'IN_B_ONLY') %}
-  {{ return(not has_data_type_match or in_a_only or in_b_only) }}
+  {{ return(not row['HAS_DATA_TYPE_MATCH'] or row['IN_A_ONLY'] or row['IN_B_ONLY']) }}
 {% endmacro %}


### PR DESCRIPTION
This is a:

- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Fix the default insight query for schema validation

## Checklist

- [x] This code is associated with an Issue which has been triaged and accepted for development
- [x] I have verified that these changes work locally on the following warehouses:
  - [x] Snowflake
  - [ ] BigQuery
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
