### PR TITLE
feat: add macro  clone_relation_extended

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Depending on projects, it might be vary in the strategy of validation. Therefore
   - Run validation macros to compare between `mart_dbt` vs `mart__YYYYMMD1` 👍
 - _Scenario 2: Validate the incremental run against D2 based on D1_
   - Configure source yml to use `source__YYYYMMD2`
-  - Clone `mart__YYYYMMD1` to `mart_dbt` to mimic that dbt should have the D1 data already (e.g. [clone_relation](./macros/dwh/clone_relation.sql))
+  - Clone `mart__YYYYMMD1` to `mart_dbt` to mimic that dbt should have the D1 data already (e.g. [clone_relation](./macros/dwh/clone_relation.sql) for a single table, or [clone_relation_extended](./macros/dwh/clone_relation_extended.sql) to also clone dependent JOIN/LOOKUP tables not maintained by the pipeline)
   - Run incrementally dbt to build mart tables
   - Run validation macros to compare between `mart_dbt` vs `mart__YYYYMMD2` 👍👍
 

--- a/docs/validation-incremental-load.md
+++ b/docs/validation-incremental-load.md
@@ -154,6 +154,36 @@ dbt run-operation clone_relation \
 
 The magic here: `use_prev: true` automatically finds Target Day1 from your `allowed_date_of_processes` list and clones `mart__20240909.dim_customer` to your target location.
 
+**Bonus: Clone target + dependent relations in one go**
+
+Instead of cloning the target model and its dependencies separately, `clone_relation_extended` does both in one call — it clones the target model itself, then walks the DAG to find and clone dependent JOIN/LOOKUP tables (source-referenced relations not maintained by the pipeline):
+
+```bash
+# Clone all sources upstream of dim_customer
+dbt run-operation clone_relation_extended \
+  --args "{'identifier': 'dim_customer'}" \
+  --vars "{'audit_helper__date_of_process': '2024-09-10'}"
+
+# Filter dependent sources by specific lookup tables
+dbt run-operation clone_relation_extended \
+  --args "{'identifier': 'dim_customer', 'source_table_names': 'dim_country,dim_currency'}"
+
+# Filter upstream models by tag
+dbt run-operation clone_relation_extended \
+  --args "{'identifier': 'dim_customer', 'tag': 'wf_daily'}"
+```
+
+To automatically exclude certain sources (e.g. RAW layer schemas you don't want to clone), define an `audit_helper_ext__source_exclusions` macro in your project:
+
+```sql
+-- macros/audit_helper_ext__source_exclusions.sql
+{% macro audit_helper_ext__source_exclusions() %}
+    {{ return({'exclude_database': 'RAW', 'exclude_schema': none}) }}
+{% endmacro %}
+```
+
+Any source whose database or schema contains the returned substring (case-insensitive) will be skipped.
+
 **Step 3: Run incremental dbt build**
 
 ```bash

--- a/macros/dwh/clone_relation.sql
+++ b/macros/dwh/clone_relation.sql
@@ -1,14 +1,15 @@
-{% macro clone_relation(identifier, source_database=none, source_schema=none, use_prev=false) %}
+{% macro clone_relation(identifier, source_database=none, source_schema=none, source_name=none, use_prev=false) %}
     {{ return(adapter.dispatch('clone_relation', 'audit_helper_ext')(
         identifier=identifier,
         source_database=source_database,
         source_schema=source_schema,
+        source_name=source_name,
         use_prev=use_prev
     )) }}
 {% endmacro %}
 
 
-{% macro default__clone_relation(identifier, source_database, source_schema, use_prev) %}
+{% macro default__clone_relation(identifier, source_database, source_schema, source_name, use_prev) %}
     {% set copy_mode = 'clone' %}
 
     {# Resolve source_identifier using naming convention #}
@@ -37,7 +38,10 @@
     {% endif %}
 
     {# checking target table #}
-    {% set dbt_relation_exists, dbt_relation, dbt_config = audit_helper_ext.get_relation(identifier=identifier) %}
+    {% set dbt_relation_exists, dbt_relation, dbt_config = audit_helper_ext.get_relation(
+        identifier=identifier,
+        source_name=source_name
+    ) %}
     {% if dbt_relation_exists == true and dbt_relation.type == 'view' %}
         {{ log("ℹ️ 🗑️  " ~ dbt_relation.identifier ~ " exists as a view, it needs to be dropped first.", true) }}
         {% do audit_helper_ext.drop_object(object_name=dbt_relation, object_type="view") %}

--- a/macros/dwh/clone_relation_extended.sql
+++ b/macros/dwh/clone_relation_extended.sql
@@ -60,7 +60,7 @@
             {{ log("[" ~ loop.index ~ "/" ~ sources_to_clone | length ~ "] Cloning - " ~ source_node.source_name ~ ":" ~ source_node.name, info=true) }}
 
             {% set versioned_schema = audit_helper_ext.get_versioned_name(
-                name=source_node.config.get('meta', {}).get('audit_helper_ext__schema'),
+                name=source_node.config.get('meta', {}).get('audit_helper_ext__source_schema'),
                 use_prev=false)
             %}
             {% do audit_helper_ext.clone_relation(

--- a/macros/dwh/clone_relation_extended.sql
+++ b/macros/dwh/clone_relation_extended.sql
@@ -32,14 +32,14 @@
         {% set sources_to_clone = audit_helper_ext.filter_source_exclusions(sources_to_clone) %}
 
         {% if sources_to_clone | length == 0 %}
-            {{ log("ℹ️  No dependent sources found for model '" ~ identifier ~ "'.", info=true) }}
+            {{ log("ℹ️  No dependent relations found for model '" ~ identifier ~ "'.", info=true) }}
             {{ return(none) }}
         {% endif %}
 
-        {{ log("ℹ️ 🔍 Found " ~ sources_to_clone | length ~ " dependent source(s) to clone for model '" ~ identifier ~ "'.", info=true) }}
+        {{ log("ℹ️ 🔍 Found " ~ sources_to_clone | length ~ " dependent relation(s) to clone for model '" ~ identifier ~ "'.", info=true) }}
 
         {% for source_node in sources_to_clone %}
-            {{ log("ℹ️ 🔄 [" ~ loop.index ~ "/" ~ sources_to_clone | length ~ "] Cloning source: " ~ source_node.source_name ~ "." ~ source_node.name, info=true) }}
+            {{ log("ℹ️ 🔄 [" ~ loop.index ~ "/" ~ sources_to_clone | length ~ "] Cloning: " ~ source_node.source_name ~ "." ~ source_node.name, info=true) }}
 
             {% set versioned_schema = audit_helper_ext.get_versioned_name(
                 name=source_node.schema,

--- a/macros/dwh/clone_relation_extended.sql
+++ b/macros/dwh/clone_relation_extended.sql
@@ -1,0 +1,59 @@
+{% macro clone_relation_extended(identifier, source_database=none, source_schema=none, source_table_names=none, tag=none, use_prev=true) %}
+    {{ return(adapter.dispatch('clone_relation_extended', 'audit_helper_ext')(
+        identifier=identifier,
+        source_database=source_database,
+        source_schema=source_schema,
+        source_table_names=source_table_names,
+        tag=tag,
+        use_prev=use_prev
+    )) }}
+{% endmacro %}
+
+
+{% macro default__clone_relation_extended(identifier, source_database, source_schema, source_table_names, tag, use_prev) %}
+
+    {% if execute %}
+        {# -- Clone the target model itself -- #}
+        {{ log("ℹ️ 📌 Cloning target model: " ~ identifier, info=true) }}
+        {% do audit_helper_ext.clone_relation(
+            identifier=identifier,
+            source_database=source_database,
+            source_schema=source_schema,
+            use_prev=use_prev
+        ) %}
+
+        {# -- Clone dependent relations (JOIN/LOOKUP tables) -- #}
+        {% set sources_to_clone = audit_helper_ext.get_dependent_source_nodes(
+            identifier=identifier,
+            source_table_names=source_table_names,
+            tag=tag
+        ) %}
+
+        {% set sources_to_clone = audit_helper_ext.filter_source_exclusions(sources_to_clone) %}
+
+        {% if sources_to_clone | length == 0 %}
+            {{ log("ℹ️  No dependent sources found for model '" ~ identifier ~ "'.", info=true) }}
+            {{ return(none) }}
+        {% endif %}
+
+        {{ log("ℹ️ 🔍 Found " ~ sources_to_clone | length ~ " dependent source(s) to clone for model '" ~ identifier ~ "'.", info=true) }}
+
+        {% for source_node in sources_to_clone %}
+            {{ log("ℹ️ 🔄 [" ~ loop.index ~ "/" ~ sources_to_clone | length ~ "] Cloning source: " ~ source_node.source_name ~ "." ~ source_node.name, info=true) }}
+
+            {% set versioned_schema = audit_helper_ext.get_versioned_name(
+                name=source_node.schema,
+                use_prev=use_prev
+            ) %}
+
+            {% do audit_helper_ext.clone_relation(
+                identifier=source_node.name,
+                source_database=source_node.database,
+                source_schema=versioned_schema,
+                use_prev=use_prev
+            ) %}
+        {% endfor %}
+
+    {% endif %}
+
+{% endmacro %}

--- a/macros/dwh/clone_relation_extended.sql
+++ b/macros/dwh/clone_relation_extended.sql
@@ -59,7 +59,10 @@
         {% for source_node in sources_to_clone %}
             {{ log("[" ~ loop.index ~ "/" ~ sources_to_clone | length ~ "] Cloning - " ~ source_node.source_name ~ ":" ~ source_node.name, info=true) }}
 
-            {% set versioned_schema = audit_helper_ext.get_versioned_name(name=source_node.schema, use_prev=false) %}
+            {% set versioned_schema = audit_helper_ext.get_versioned_name(
+                name=source_node.config.get('meta', {}).get('audit_helper_ext__schema'),
+                use_prev=false)
+            %}
             {% do audit_helper_ext.clone_relation(
                 identifier=source_node.name,
                 source_database=source_node.database,

--- a/macros/dwh/clone_relation_extended.sql
+++ b/macros/dwh/clone_relation_extended.sql
@@ -49,8 +49,9 @@
 
             {% do audit_helper_ext.clone_relation(
                 identifier=source_node.name,
-                source_database=source_node.database,
+                source_database=source_database,
                 source_schema=versioned_schema,
+                source_name=source_node.source_name,
                 use_prev=use_prev
             ) %}
         {% endfor %}

--- a/macros/dwh/clone_relation_extended.sql
+++ b/macros/dwh/clone_relation_extended.sql
@@ -38,13 +38,14 @@
 
         {{ log("ℹ️ 🔍 Found " ~ sources_to_clone | length ~ " dependent relation(s) to clone for model '" ~ identifier ~ "'.", info=true) }}
 
+        {# -- Use the same versioned schema as the target model -- #}
+        {% set versioned_schema = audit_helper_ext.get_versioned_name(
+            name=var('audit_helper__source_schema', target.schema),
+            use_prev=use_prev
+        ) %}
+
         {% for source_node in sources_to_clone %}
             {{ log("ℹ️ 🔄 [" ~ loop.index ~ "/" ~ sources_to_clone | length ~ "] Cloning: " ~ source_node.source_name ~ "." ~ source_node.name, info=true) }}
-
-            {% set versioned_schema = audit_helper_ext.get_versioned_name(
-                name=source_node.schema,
-                use_prev=use_prev
-            ) %}
 
             {% do audit_helper_ext.clone_relation(
                 identifier=source_node.name,

--- a/macros/dwh/clone_relation_extended.sql
+++ b/macros/dwh/clone_relation_extended.sql
@@ -34,8 +34,12 @@
         {# -- Exclude the target model itself from dependent relations -- #}
         {% set filtered = [] %}
         {% for source_node in sources_to_clone %}
-            {% if source_node.name == identifier %}
-                {{ log("⚠️  Excluding target model '" ~ identifier ~ "' from dependent relations (might be already cloned above).", info=true) }}
+            {% if (source_node.name | upper == identifier | upper) 
+                and (source_node.config.get(meta, {}).get("audit_helper_ext__ignore_cyclic_deps", 0) == 0) %}
+                {{ log(
+                    "⚠️  Excluding dependent relation '" ~ source_node.source_name ~ ":" ~ source_node.name ~ "' (potential cyclic dependencies)."
+                    " Add <source>.config.meta.audit_helper_ext__ignore_cyclic_deps = 1 to bypass this exclusion.", info=true)
+                }}
             {% else %}
                 {% do filtered.append(source_node) %}
             {% endif %}
@@ -47,13 +51,13 @@
             {{ return(none) }}
         {% endif %}
 
-        {{ log("ℹ️ 🔍 Found " ~ sources_to_clone | length ~ " dependent relation(s) to clone for model '" ~ identifier ~ "':", info=true) }}
+        {{ log("Found " ~ sources_to_clone | length ~ " dependent relation(s) to clone for model '" ~ identifier ~ "':", info=true) }}
         {% for source_node in sources_to_clone %}
-            {{ log("ℹ️     " ~ loop.index ~ ". " ~ source_node.source_name ~ ":" ~ source_node.name, info=true) }}
+            {{ log("  " ~ loop.index ~ ". " ~ source_node.source_name ~ ":" ~ source_node.name, info=true) }}
         {% endfor %}
 
         {% for source_node in sources_to_clone %}
-            {{ log("ℹ️ 🔄 [" ~ loop.index ~ "/" ~ sources_to_clone | length ~ "] Cloning - " ~ source_node.source_name ~ ":" ~ source_node.name, info=true) }}
+            {{ log("[" ~ loop.index ~ "/" ~ sources_to_clone | length ~ "] Cloning - " ~ source_node.source_name ~ ":" ~ source_node.name, info=true) }}
 
             {% set versioned_schema = audit_helper_ext.get_versioned_name(name=source_node.schema, use_prev=false) %}
             {% do audit_helper_ext.clone_relation(

--- a/macros/dwh/clone_relation_extended.sql
+++ b/macros/dwh/clone_relation_extended.sql
@@ -31,28 +31,37 @@
 
         {% set sources_to_clone = audit_helper_ext.filter_source_exclusions(sources_to_clone) %}
 
+        {# -- Exclude the target model itself from dependent relations -- #}
+        {% set filtered = [] %}
+        {% for source_node in sources_to_clone %}
+            {% if source_node.name == identifier %}
+                {{ log("⚠️  Excluding target model '" ~ identifier ~ "' from dependent relations (might be already cloned above).", info=true) }}
+            {% else %}
+                {% do filtered.append(source_node) %}
+            {% endif %}
+        {% endfor %}
+        {% set sources_to_clone = filtered %}
+
         {% if sources_to_clone | length == 0 %}
             {{ log("ℹ️  No dependent relations found for model '" ~ identifier ~ "'.", info=true) }}
             {{ return(none) }}
         {% endif %}
 
-        {{ log("ℹ️ 🔍 Found " ~ sources_to_clone | length ~ " dependent relation(s) to clone for model '" ~ identifier ~ "'.", info=true) }}
-
-        {# -- Use the same versioned schema as the target model -- #}
-        {% set versioned_schema = audit_helper_ext.get_versioned_name(
-            name=var('audit_helper__source_schema', target.schema),
-            use_prev=use_prev
-        ) %}
+        {{ log("ℹ️ 🔍 Found " ~ sources_to_clone | length ~ " dependent relation(s) to clone for model '" ~ identifier ~ "':", info=true) }}
+        {% for source_node in sources_to_clone %}
+            {{ log("ℹ️     " ~ loop.index ~ ". " ~ source_node.source_name ~ ":" ~ source_node.name, info=true) }}
+        {% endfor %}
 
         {% for source_node in sources_to_clone %}
-            {{ log("ℹ️ 🔄 [" ~ loop.index ~ "/" ~ sources_to_clone | length ~ "] Cloning: " ~ source_node.source_name ~ "." ~ source_node.name, info=true) }}
+            {{ log("ℹ️ 🔄 [" ~ loop.index ~ "/" ~ sources_to_clone | length ~ "] Cloning - " ~ source_node.source_name ~ ":" ~ source_node.name, info=true) }}
 
+            {% set versioned_schema = audit_helper_ext.get_versioned_name(name=source_node.schema, use_prev=false) %}
             {% do audit_helper_ext.clone_relation(
                 identifier=source_node.name,
-                source_database=source_database,
+                source_database=source_node.database,
                 source_schema=versioned_schema,
                 source_name=source_node.source_name,
-                use_prev=use_prev
+                use_prev=false
             ) %}
         {% endfor %}
 

--- a/macros/dwh/clone_relation_extended.yml
+++ b/macros/dwh/clone_relation_extended.yml
@@ -1,0 +1,25 @@
+macros:
+  - name: clone_relation_extended
+    description: |
+      Clone a target model and its dependent relations (JOIN/LOOKUP tables) in one operation.
+
+      First clones the target model itself via `clone_relation`, then walks the DAG to find
+      dependent source tables not maintained by the pipeline and clones those too.
+      Uses `filter_source_exclusions` to skip sources you don't want cloned.
+
+      Supports all `clone_relation` parameters (`source_database`, `source_schema`, `use_prev`)
+      for the target model clone, plus `source_table_names` and `tag` for filtering dependent sources.
+
+      ```shell
+      # Clone dim_customer and all its dependent sources
+      dbt run-operation clone_relation_extended --args '{identifier: dim_customer}'
+
+      # Specify source location for the target model
+      dbt run-operation clone_relation_extended --args '{identifier: dim_customer, source_database: RAW_DB, source_schema: RAW_SCHEMA}'
+
+      # Filter dependent sources by table names (e.g. specific lookup tables)
+      dbt run-operation clone_relation_extended --args '{identifier: dim_customer, source_table_names: "dim_country,dim_currency"}'
+
+      # Filter upstream models by tag
+      dbt run-operation clone_relation_extended --args '{identifier: dim_customer, tag: wf_daily}'
+      ```

--- a/macros/relation/get_relation.sql
+++ b/macros/relation/get_relation.sql
@@ -1,17 +1,21 @@
-{% macro get_relation(identifier, identifier_database=none, identifier_schema=none, node_name=none) %}
+{% macro get_relation(identifier, identifier_database=none, identifier_schema=none, node_name=none, source_name=none) %}
   {% set node_name = node_name or identifier %}
   {{ return(adapter.dispatch('get_relation', 'audit_helper_ext')(
       identifier=identifier,
       identifier_database=identifier_database,
       identifier_schema=identifier_schema,
-      node_name=node_name
+      node_name=node_name,
+      source_name=source_name
   )) }}
 {% endmacro %}
 
 
-{% macro default__get_relation(identifier, identifier_database, identifier_schema, node_name) %}
+{% macro default__get_relation(identifier, identifier_database, identifier_schema, node_name, source_name) %}
 
     {% set node = audit_helper_ext.get_model_node(node_name) %}
+    {% if node.name == 'undefined' and source_name %}
+        {% set node = audit_helper_ext.get_source_node(source_name=source_name, identifier=node_name) %}
+    {% endif %}
 
     {% set database = identifier_database or node.database %}
     {% set schema = identifier_schema or node.schema %}

--- a/macros/relation/get_source_node.sql
+++ b/macros/relation/get_source_node.sql
@@ -1,0 +1,24 @@
+{% macro get_source_node(source_name, identifier) %}
+  {{ return(adapter.dispatch('get_source_node', 'audit_helper_ext')(source_name=source_name, identifier=identifier)) }}
+{% endmacro %}
+
+
+{% macro default__get_source_node(source_name, identifier) %}
+
+    {% set ns = namespace() %}
+    {% set ns.node = [] %}
+    {% for node in graph.sources.values()
+        | selectattr("source_name", "equalto", source_name | trim)
+        | selectattr("name", "equalto", identifier | trim)
+    %}
+        {% do ns.node.append(node) %}
+    {% endfor -%}
+    {% if ns.node | length > 0 %}
+        {% set first_node = ns.node[0] %}
+    {% else %}
+        {% set first_node = {'name': 'undefined'} %}
+    {% endif %}
+
+    {{ return(first_node) }}
+
+{% endmacro %}

--- a/macros/relation/get_source_node.yml
+++ b/macros/relation/get_source_node.yml
@@ -1,0 +1,6 @@
+macros:
+  - name: get_source_node
+    description: |
+        Get the full node for a source table in the dbt project, identified by source_name and table name.
+
+        Useful to get the database, schema, and config for a source.

--- a/macros/utility/lineage/filter_source_exclusions.sql
+++ b/macros/utility/lineage/filter_source_exclusions.sql
@@ -7,18 +7,19 @@
 
 {% macro default__filter_source_exclusions(source_nodes) %}
 
-    {% set audit_helper_ext__source_exclusions = context.get('audit_helper_ext__source_exclusions', none) %}
-    {% if audit_helper_ext__source_exclusions is none %}
+    {% set call__source_exclusions = context.get('audit_helper_ext__source_exclusions', none) %}
+    {% if call__source_exclusions is none %}
         {{ return(source_nodes) }}
     {% endif %}
 
-    {% set exclude_database, exclude_schema = audit_helper_ext__source_exclusions() %}
+    {% set exclude_database, exclude_schema = call__source_exclusions() %}
     {% set filtered_sources = [] %}
     {% for source_node in source_nodes %}
         {% set db_match = exclude_database is not none and (exclude_database | upper) in (source_node.database | upper) %}
         {% set schema_match = exclude_schema is not none and (exclude_schema | upper) in (source_node.schema | upper) %}
         {% if db_match or schema_match %}
-            {{ log("ℹ️ ⏭️  Excluding source " ~ source_node.source_name ~ "." ~ source_node.name ~ " (matched source_exclusions: database='" ~ source_node.database ~ "', schema='" ~ source_node.schema ~ "').", info=true) }}
+            {{ log("ℹ️ ⏭️  Excluding relation " ~ source_node.source_name ~ "." ~ source_node.name 
+                ~ " (matched source_exclusions: database='" ~ source_node.database ~ "', schema='" ~ source_node.schema ~ "').", info=true) }}
         {% else %}
             {% do filtered_sources.append(source_node) %}
         {% endif %}

--- a/macros/utility/lineage/filter_source_exclusions.sql
+++ b/macros/utility/lineage/filter_source_exclusions.sql
@@ -1,0 +1,29 @@
+{% macro filter_source_exclusions(source_nodes) %}
+    {{ return(adapter.dispatch('filter_source_exclusions', 'audit_helper_ext')(
+        source_nodes=source_nodes
+    )) }}
+{% endmacro %}
+
+
+{% macro default__filter_source_exclusions(source_nodes) %}
+
+    {% set audit_helper_ext__source_exclusions = context.get('audit_helper_ext__source_exclusions', none) %}
+    {% if audit_helper_ext__source_exclusions is none %}
+        {{ return(source_nodes) }}
+    {% endif %}
+
+    {% set exclude_database, exclude_schema = audit_helper_ext__source_exclusions() %}
+    {% set filtered_sources = [] %}
+    {% for source_node in source_nodes %}
+        {% set db_match = exclude_database is not none and (exclude_database | upper) in (source_node.database | upper) %}
+        {% set schema_match = exclude_schema is not none and (exclude_schema | upper) in (source_node.schema | upper) %}
+        {% if db_match or schema_match %}
+            {{ log("ℹ️ ⏭️  Excluding source " ~ source_node.source_name ~ "." ~ source_node.name ~ " (matched source_exclusions: database='" ~ source_node.database ~ "', schema='" ~ source_node.schema ~ "').", info=true) }}
+        {% else %}
+            {% do filtered_sources.append(source_node) %}
+        {% endif %}
+    {% endfor %}
+
+    {{ return(filtered_sources) }}
+
+{% endmacro %}

--- a/macros/utility/lineage/filter_source_exclusions.sql
+++ b/macros/utility/lineage/filter_source_exclusions.sql
@@ -18,10 +18,7 @@
     {% for source_node in source_nodes %}
         {% set db_match = exclude_database is not none and (exclude_database | upper) in (source_node.database | upper) %}
         {% set schema_match = exclude_schema is not none and (exclude_schema | upper) in (source_node.schema | upper) %}
-        {% if db_match or schema_match %}
-            {{ log("⏭️  Excluding relation " ~ source_node.source_name ~ "." ~ source_node.name 
-                ~ " (matched source_exclusions: database='" ~ source_node.database ~ "', schema='" ~ source_node.schema ~ "').", info=true) }}
-        {% else %}
+        {% if not (db_match or schema_match) %}
             {% do filtered_sources.append(source_node) %}
         {% endif %}
     {% endfor %}

--- a/macros/utility/lineage/filter_source_exclusions.sql
+++ b/macros/utility/lineage/filter_source_exclusions.sql
@@ -19,7 +19,7 @@
         {% set db_match = exclude_database is not none and (exclude_database | upper) in (source_node.database | upper) %}
         {% set schema_match = exclude_schema is not none and (exclude_schema | upper) in (source_node.schema | upper) %}
         {% if db_match or schema_match %}
-            {{ log("ℹ️ ⏭️  Excluding relation " ~ source_node.source_name ~ "." ~ source_node.name 
+            {{ log("⏭️  Excluding relation " ~ source_node.source_name ~ "." ~ source_node.name 
                 ~ " (matched source_exclusions: database='" ~ source_node.database ~ "', schema='" ~ source_node.schema ~ "').", info=true) }}
         {% else %}
             {% do filtered_sources.append(source_node) %}

--- a/macros/utility/lineage/filter_source_exclusions.sql
+++ b/macros/utility/lineage/filter_source_exclusions.sql
@@ -11,8 +11,9 @@
     {% if call__source_exclusions is none %}
         {{ return(source_nodes) }}
     {% endif %}
-
-    {% set exclude_database, exclude_schema = call__source_exclusions() %}
+    {% set exclude_config = call__source_exclusions() %}
+    {% set exclude_database = exclude_config.get('exclude_database', none) %}
+    {% set exclude_schema = exclude_config.get('exclude_schema', none) %}
     {% set filtered_sources = [] %}
     {% for source_node in source_nodes %}
         {% set db_match = exclude_database is not none and (exclude_database | upper) in (source_node.database | upper) %}

--- a/macros/utility/lineage/get_dependent_source_nodes.sql
+++ b/macros/utility/lineage/get_dependent_source_nodes.sql
@@ -1,0 +1,83 @@
+{% macro get_dependent_source_nodes(identifier, source_table_names=none, tag=none) %}
+    {{ return(adapter.dispatch('get_dependent_source_nodes', 'audit_helper_ext')(
+        identifier=identifier,
+        source_table_names=source_table_names,
+        tag=tag
+    )) }}
+{% endmacro %}
+
+
+{% macro default__get_dependent_source_nodes(identifier, source_table_names, tag) %}
+
+    {# -- Parse source_table_names into a list -- #}
+    {% set source_table_name_list = [] %}
+    {% if source_table_names is not none %}
+        {% for s in source_table_names.split(',') %}
+            {% set trimmed = s | trim %}
+            {% if trimmed %}
+                {% do source_table_name_list.append(trimmed) %}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+
+    {# -- Get target model node -- #}
+    {% set target_node = audit_helper_ext.get_model_node(identifier) %}
+    {% if target_node.name == 'undefined' %}
+        {% do exceptions.raise_compiler_error(
+            "❌ Model '" ~ identifier ~ "' not found in the dbt graph."
+        ) %}
+    {% endif %}
+
+    {# -- Collect upstream models (including target) from lineage paths -- #}
+    {% set lineage_paths = audit_helper_ext.get_upstream_lineage(identifier) %}
+
+    {% set upstream_model_ids = [] %}
+    {% for path in lineage_paths %}
+        {% for node_info in path %}
+            {% if node_info.type == 'model' and node_info.unique_id not in upstream_model_ids %}
+                {% do upstream_model_ids.append(node_info.unique_id) %}
+            {% endif %}
+        {% endfor %}
+    {% endfor %}
+
+    {# -- Filter models by tag (if provided) -- #}
+    {% set filtered_model_ids = [] %}
+    {% if tag is not none %}
+        {% for model_id in upstream_model_ids %}
+            {% set model_node = graph.nodes.get(model_id) %}
+            {% if model_node and tag in model_node.tags %}
+                {% do filtered_model_ids.append(model_id) %}
+            {% endif %}
+        {% endfor %}
+    {% else %}
+        {% set filtered_model_ids = upstream_model_ids %}
+    {% endif %}
+
+    {# -- Collect source dependencies from filtered models -- #}
+    {% set source_unique_ids = [] %}
+    {% for model_id in filtered_model_ids %}
+        {% set model_node = graph.nodes.get(model_id) %}
+        {% if model_node %}
+            {% set depends_on_nodes = model_node.get('depends_on', {}).get('nodes', []) %}
+            {% for dep_id in depends_on_nodes %}
+                {% if dep_id.startswith('source.') and dep_id not in source_unique_ids %}
+                    {% do source_unique_ids.append(dep_id) %}
+                {% endif %}
+            {% endfor %}
+        {% endif %}
+    {% endfor %}
+
+    {# -- Resolve source nodes and filter by source_table_names -- #}
+    {% set source_nodes = [] %}
+    {% for source_id in source_unique_ids %}
+        {% set source_node = graph.sources.get(source_id) %}
+        {% if source_node %}
+            {% if source_table_name_list | length == 0 or source_node.name in source_table_name_list %}
+                {% do source_nodes.append(source_node) %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+
+    {{ return(source_nodes) }}
+
+{% endmacro %}


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
resolves #

This is a:

- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation

Introduces the `clone_relation_extended` macro — an advanced cloning utility that clones a target dbt model **and all its dependent source relations** (JOIN/LOOKUP tables) in a single operation. This is essential for incremental data validation workflows in migration projects, where you need to reproduce the entire upstream dependency chain before running incremental models.

## Checklist

- [x] This code is associated with an Issue which has been triaged and accepted for development
- [x] I have verified that these changes work locally on the following warehouses:
  - [x] Snowflake
  - [ ] BigQuery
  - [ ] SQLServer
  - [ ] PostgreSQL
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)