### PR TITLE
feat: extend clone_relation_extended macro to include exclude_identifers for filtering dependent sources

### DIFF
--- a/macros/dwh/clone_relation_extended.sql
+++ b/macros/dwh/clone_relation_extended.sql
@@ -1,16 +1,17 @@
-{% macro clone_relation_extended(identifiers, source_database=none, source_schema=none, dependant_table_names=none, tag=none, use_prev=true) %}
+{% macro clone_relation_extended(identifiers, source_database=none, source_schema=none, dependant_table_names=none, tag=none, use_prev=true, exclude_identifiers=none) %}
     {{ return(adapter.dispatch('clone_relation_extended', 'audit_helper_ext')(
         identifiers=identifiers,
         source_database=source_database,
         source_schema=source_schema,
         dependant_table_names=dependant_table_names,
         tag=tag,
-        use_prev=use_prev
+        use_prev=use_prev,
+        exclude_identifiers=exclude_identifiers
     )) }}
 {% endmacro %}
 
 
-{% macro default__clone_relation_extended(identifiers, source_database, source_schema, dependant_table_names, tag, use_prev) %}
+{% macro default__clone_relation_extended(identifiers, source_database, source_schema, dependant_table_names, tag, use_prev, exclude_identifiers) %}
 
     {% if execute %}
         {# -- Parse comma-separated identifiers into a list -- #}
@@ -34,7 +35,7 @@
             tag=tag
         ) %}
 
-        {% set sources_to_clone = audit_helper_ext.filter_source_exclusions(all_sources, identifiers=identifiers) %}
+        {% set sources_to_clone = audit_helper_ext.filter_source_exclusions(all_sources, identifiers=identifiers, exclude_identifiers=exclude_identifiers) %}
         {% if sources_to_clone | length == 0 %}
             {{ log("ℹ️  No dependent relations found for model(s) '" ~ identifier_list | join("', '") ~ "'.", info=true) }}
             {{ return(none) }}

--- a/macros/dwh/clone_relation_extended.yml
+++ b/macros/dwh/clone_relation_extended.yml
@@ -9,7 +9,8 @@ macros:
       Uses `filter_source_exclusions` to skip sources you don't want cloned.
 
       Supports all `clone_relation` parameters (`source_database`, `source_schema`, `use_prev`)
-      for the target model clone, plus `dependant_table_names` and `tag` for filtering dependent sources.
+      for the target model clone, plus `dependant_table_names` and `tag` for filtering dependent sources,
+      and `exclude_identifiers` to skip specific dependent sources by name.
 
       ```shell
       # Clone dim_customer and all its dependent sources
@@ -26,4 +27,7 @@ macros:
 
       # Filter upstream models by tag
       dbt run-operation clone_relation_extended --args '{identifiers: dim_customer, tag: wf_daily}'
+
+      # Skip specific dependent sources by identifier (comma-separated)
+      dbt run-operation clone_relation_extended --args '{identifiers: dim_customer, exclude_identifiers: "dim_country,dim_currency"}'
       ```

--- a/macros/utility/lineage/filter_source_exclusions.sql
+++ b/macros/utility/lineage/filter_source_exclusions.sql
@@ -1,12 +1,13 @@
-{% macro filter_source_exclusions(source_nodes, identifiers=none) %}
+{% macro filter_source_exclusions(source_nodes, identifiers=none, exclude_identifiers=none) %}
     {{ return(adapter.dispatch('filter_source_exclusions', 'audit_helper_ext')(
         source_nodes=source_nodes,
-        identifiers=identifiers
+        identifiers=identifiers,
+        exclude_identifiers=exclude_identifiers
     )) }}
 {% endmacro %}
 
 
-{% macro default__filter_source_exclusions(source_nodes, identifiers) %}
+{% macro default__filter_source_exclusions(source_nodes, identifiers, exclude_identifiers) %}
 
     {% set filtered_sources = [] %}
 
@@ -26,6 +27,22 @@
         {% endfor %}
     {% else %}
         {% set filtered_sources = source_nodes | list %}
+    {% endif %}
+
+    {# -- Exclude sources by user-supplied identifier list -- #}
+    {% if exclude_identifiers is not none %}
+        {% set exclude_upper_list = exclude_identifiers.split(',') | map('trim') | select | map('upper') | list %}
+        {% set user_filtered_sources = [] %}
+        {% for source_node in filtered_sources %}
+            {% if source_node.name | upper in exclude_upper_list %}
+                {{ log(
+                    "⚠️  Excluding dependent relation '" ~ source_node.source_name ~ ":" ~ source_node.name ~ "' (matched exclude_identifiers).", info=true)
+                }}
+            {% else %}
+                {% do user_filtered_sources.append(source_node) %}
+            {% endif %}
+        {% endfor %}
+        {% set filtered_sources = user_filtered_sources %}
     {% endif %}
 
     {# -- Exclude sources by database/schema patterns (user-defined hook) -- #}


### PR DESCRIPTION
This is a:

- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Add `exclude_identifiers` arg to `clone_relation_extended` macro

## Checklist

- [x] This code is associated with an Issue which has been triaged and accepted for development
- [x] I have verified that these changes work locally on the following warehouses:
  - [x] Snowflake
  - [ ] BigQuery
  - [ ] SQLServer
  - [ ] PostgreSQL
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
