### PR TITLE
feat: enhance clone_relation_extended macro to skip excluded target models during cloning

### DIFF
--- a/macros/dwh/clone_relation_extended.sql
+++ b/macros/dwh/clone_relation_extended.sql
@@ -16,16 +16,21 @@
     {% if execute %}
         {# -- Parse comma-separated identifiers into a list -- #}
         {% set identifier_list = identifiers.split(',') | map('trim') | select | list %}
+        {% set excluded_list = (exclude_identifiers or '').split(',') | map('trim') | select | list %}
 
-        {# -- Clone each target model -- #}
+        {# -- Clone each target model, skipping any listed in exclude_identifiers -- #}
         {% for id in identifier_list %}
-            {{ log("📌 Cloning target model: " ~ id, info=true) }}
-            {% do audit_helper_ext.clone_relation(
-                identifier=id,
-                source_database=source_database,
-                source_schema=source_schema,
-                use_prev=use_prev
-            ) %}
+            {% if id in excluded_list %}
+                {{ log("⏭️  Skipping excluded target model: " ~ id, info=true) }}
+            {% else %}
+                {{ log("📌 Cloning target model: " ~ id, info=true) }}
+                {% do audit_helper_ext.clone_relation(
+                    identifier=id,
+                    source_database=source_database,
+                    source_schema=source_schema,
+                    use_prev=use_prev
+                ) %}
+            {% endif %}
         {% endfor %}
 
         {# -- Collect dependent relations (JOIN/LOOKUP tables) across all identifiers -- #}


### PR DESCRIPTION
This is a:

- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Enhance `clone_relation_extended` macro to skip excluded target models during cloning

## Checklist

- [x] This code is associated with an Issue which has been triaged and accepted for development
- [x] I have verified that these changes work locally on the following warehouses:
  - [x] Snowflake
  - [ ] BigQuery
  - [ ] SQLServer
  - [ ] PostgreSQL
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
