### PR TITLE
fix(fusion): dispatch filter macros via adapter.dispatch

### DIFF
--- a/macros/utility/filter_validation_result/filter_count_validation.sql
+++ b/macros/utility/filter_validation_result/filter_count_validation.sql
@@ -1,4 +1,8 @@
 {% macro filter_count_validation_mismatch(result) %}
+  {{ return(adapter.dispatch('filter_count_validation_mismatch', 'audit_helper_ext')(result=result)) }}
+{% endmacro %}
+
+{% macro default__filter_count_validation_mismatch(result) %}
   {% if result.rows | length != 2 %}
     {{ return(false) }}
   {% endif %}
@@ -9,6 +13,10 @@
 {% endmacro %}
 
 {% macro filter_count_validation_equal_zero(result) %}
+  {{ return(adapter.dispatch('filter_count_validation_equal_zero', 'audit_helper_ext')(result=result)) }}
+{% endmacro %}
+
+{% macro default__filter_count_validation_equal_zero(result) %}
   {% if result.rows | length != 2 %}
     {{ return(false) }}
   {% endif %}

--- a/macros/utility/filter_validation_result/filter_full_validation.sql
+++ b/macros/utility/filter_validation_result/filter_full_validation.sql
@@ -1,10 +1,18 @@
 {% macro filter_full_validation_in_a_not_b(row) %}
+  {{ return(adapter.dispatch('filter_full_validation_in_a_not_b', 'audit_helper_ext')(row=row)) }}
+{% endmacro %}
+
+{% macro default__filter_full_validation_in_a_not_b(row) %}
   {% set in_a_col = audit_helper_ext.get_actual_column_name(row, 'IN_A') %}
   {% set in_b_col = audit_helper_ext.get_actual_column_name(row, 'IN_B') %}
   {{ return(row[in_a_col] and not row[in_b_col]) }}
 {% endmacro %}
 
 {% macro filter_full_validation_in_b_not_a(row) %}
+  {{ return(adapter.dispatch('filter_full_validation_in_b_not_a', 'audit_helper_ext')(row=row)) }}
+{% endmacro %}
+
+{% macro default__filter_full_validation_in_b_not_a(row) %}
   {% set in_a_col = audit_helper_ext.get_actual_column_name(row, 'IN_A') %}
   {% set in_b_col = audit_helper_ext.get_actual_column_name(row, 'IN_B') %}
   {{ return(row[in_b_col] and not row[in_a_col]) }}

--- a/macros/utility/filter_validation_result/filter_schema_validation.sql
+++ b/macros/utility/filter_validation_result/filter_schema_validation.sql
@@ -1,4 +1,8 @@
 {% macro filter_schema_validation_mismatch_data_type(row) %}
+  {{ return(adapter.dispatch('filter_schema_validation_mismatch_data_type', 'audit_helper_ext')(row=row)) }}
+{% endmacro %}
+
+{% macro default__filter_schema_validation_mismatch_data_type(row) %}
   {% set has_data_type_match_col = audit_helper_ext.get_actual_column_name(row, 'HAS_DATA_TYPE_MATCH') %}
   {% set in_both_col = audit_helper_ext.get_actual_column_name(row, 'IN_BOTH') %}
   {% set in_a_only = audit_helper_ext.get_actual_column_name(row, 'IN_A_ONLY') %}
@@ -15,26 +19,50 @@
 {% endmacro %}
 
 {% macro filter_schema_validation_mismatch_ordinal_position(row) %}
+  {{ return(adapter.dispatch('filter_schema_validation_mismatch_ordinal_position', 'audit_helper_ext')(row=row)) }}
+{% endmacro %}
+
+{% macro default__filter_schema_validation_mismatch_ordinal_position(row) %}
   {{ return(audit_helper_ext._filter_schema_validation_mismatch_attribute(row, 'HAS_ORDINAL_POSITION_MATCH')) }}
 {% endmacro %}
 
 {% macro filter_schema_validation_mismatch_character_maximum_length(row) %}
+  {{ return(adapter.dispatch('filter_schema_validation_mismatch_character_maximum_length', 'audit_helper_ext')(row=row)) }}
+{% endmacro %}
+
+{% macro default__filter_schema_validation_mismatch_character_maximum_length(row) %}
   {{ return(audit_helper_ext._filter_schema_validation_mismatch_attribute(row, 'HAS_CHARACTER_MAXIMUM_LENGTH_MATCH')) }}
 {% endmacro %}
 
 {% macro filter_schema_validation_mismatch_numeric_precision(row) %}
+  {{ return(adapter.dispatch('filter_schema_validation_mismatch_numeric_precision', 'audit_helper_ext')(row=row)) }}
+{% endmacro %}
+
+{% macro default__filter_schema_validation_mismatch_numeric_precision(row) %}
   {{ return(audit_helper_ext._filter_schema_validation_mismatch_attribute(row, 'HAS_NUMERIC_PRECISION_MATCH')) }}
 {% endmacro %}
 
 {% macro filter_schema_validation_mismatch_numeric_scale(row) %}
+  {{ return(adapter.dispatch('filter_schema_validation_mismatch_numeric_scale', 'audit_helper_ext')(row=row)) }}
+{% endmacro %}
+
+{% macro default__filter_schema_validation_mismatch_numeric_scale(row) %}
   {{ return(audit_helper_ext._filter_schema_validation_mismatch_attribute(row, 'HAS_NUMERIC_SCALE_MATCH')) }}
 {% endmacro %}
 
 {% macro filter_schema_validation_mismatch_is_nullable(row) %}
+  {{ return(adapter.dispatch('filter_schema_validation_mismatch_is_nullable', 'audit_helper_ext')(row=row)) }}
+{% endmacro %}
+
+{% macro default__filter_schema_validation_mismatch_is_nullable(row) %}
   {{ return(audit_helper_ext._filter_schema_validation_mismatch_attribute(row, 'HAS_IS_NULLABLE_MATCH')) }}
 {% endmacro %}
 
 {% macro filter_schema_validation_in_a_only(row) %}
+  {{ return(adapter.dispatch('filter_schema_validation_in_a_only', 'audit_helper_ext')(row=row)) }}
+{% endmacro %}
+
+{% macro default__filter_schema_validation_in_a_only(row) %}
   {% set in_a_only_col = audit_helper_ext.get_actual_column_name(row, 'IN_A_ONLY') %}
   {{ return(row[in_a_only_col]) }}
 {% endmacro %}
@@ -44,6 +72,10 @@
 {# Falls back to mismatch_data_type + in_a_only if the var is unset or empty, #}
 {# matching the pre-configurable behavior so silent-no-op never happens. #}
 {% macro filter_schema_validation_enabled_errors(row) %}
+  {{ return(adapter.dispatch('filter_schema_validation_enabled_errors', 'audit_helper_ext')(row=row)) }}
+{% endmacro %}
+
+{% macro default__filter_schema_validation_enabled_errors(row) %}
   {% set enabled_suffixes = var('audit_helper__schema_validation_checks', ['mismatch_data_type', 'in_a_only']) %}
 
   {% set in_a_only_col = audit_helper_ext.get_actual_column_name(row, 'IN_A_ONLY') %}

--- a/macros/utility/filter_validation_result/filter_upstream_row_count_validation.sql
+++ b/macros/utility/filter_validation_result/filter_upstream_row_count_validation.sql
@@ -1,4 +1,8 @@
 {% macro filter_upstream_row_count_validation_equal_zero(row) %}
+  {{ return(adapter.dispatch('filter_upstream_row_count_validation_equal_zero', 'audit_helper_ext')(row=row)) }}
+{% endmacro %}
+
+{% macro default__filter_upstream_row_count_validation_equal_zero(row) %}
   {% set row_count_col = audit_helper_ext.get_actual_column_name(row, 'ROW_COUNT') %}
   {{ return(row[row_count_col] == 0) }}
 {% endmacro %}

--- a/macros/utility/print_validation_result_status.sql
+++ b/macros/utility/print_validation_result_status.sql
@@ -29,7 +29,7 @@
   {% for filter_config in filters %}
     {% set filter_description = filter_config.description %}
     {% set filter_macro = filter_config.macro %}
-    {% set filter_macro_call = context.get(filter_macro, none) or audit_helper_ext.get(filter_macro) %}
+    {% set filter_macro_call = audit_helper_ext[filter_macro] %}
     {% set failed_calc_config = filter_config.failed_calc | default(namespace(agg=none, column=none)) %}
 
     {# For count validation: table level #}

--- a/macros/validation/get_validation_schema.sql
+++ b/macros/validation/get_validation_schema.sql
@@ -34,7 +34,7 @@
     ) %}
 
     {% if execute %}
-      {% set audit_results = audit_helper_ext.run_audit_query(query=audit_query, filter=audit_helper_ext["filter_schema_validation_enabled_errors"]) %}
+      {% set audit_results = audit_helper_ext.run_audit_query(query=audit_query, filter=adapter.dispatch('filter_schema_validation_enabled_errors', 'audit_helper_ext')) %}
       {{ audit_helper_ext.log_validation_result('schema', audit_results, dbt_identifier, dbt_relation, old_relation) }}
     {% endif %}
 


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
resolves #

This is a:

- [ ] documentation update
- [ ] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change
- [x] fusion compat fix with no breaking changes

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Convert the validation-result filter macros to `adapter.dispatch` so they can be overridden per adapter.

- Wrap all `filter_*_validation_*` macros with a `adapter.dispatch(...)` entry point plus a `default__` implementation (count, full, schema, upstream_row_count).
- Update `print_validation_result_status.sql` to resolve filters via `audit_helper_ext[filter_macro]` instead of `context.get(...) or audit_helper_ext.get(...)`.
- Update `get_validation_schema.sql` to pass the filter through `adapter.dispatch('filter_schema_validation_enabled_errors', 'audit_helper_ext')`.

Adapter-specific behavior can now be supplied via `<adapter>__` overrides without touching package internals. The optional user hook in `filter_source_exclusions.sql` is intentionally left on `context.get(...)`, since that resolves a user-defined macro in the root project namespace.

## Checklist

- [ ] This code is associated with an Issue which has been triaged and accepted for development
- [x] I have verified that these changes work locally on the following warehouses:
  - [x] Snowflake
  - [ ] BigQuery
  - [ ] SQLServer
  - [ ] PostgreSQL
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
