### PR TITLE
feat(relation): add package-scoped node lookup

### DIFF
--- a/integration_tests/macros/test__package_scoped_lookup.sql
+++ b/integration_tests/macros/test__package_scoped_lookup.sql
@@ -1,0 +1,81 @@
+{% macro assert_equal(actual, expected, what) %}
+    {% if actual != expected %}
+        {% do exceptions.raise_compiler_error(
+            "❌ " ~ what ~ ": expected '" ~ expected ~ "' but got '" ~ actual ~ "'."
+        ) %}
+    {% endif %}
+    {{ log("✅ " ~ what ~ " == '" ~ expected ~ "'", info=true) }}
+{% endmacro %}
+
+
+{% macro test__package_scoped_lookup() %}
+
+    {% if not execute %}{{ return(none) }}{% endif %}
+
+    {% set unique_node = audit_helper_ext.get_model_node('pkg_unique_model') %}
+    {{ assert_equal(
+        unique_node.name, 'pkg_unique_model', "unique model resolves by name") }}
+    {{ assert_equal(
+        unique_node.package_name, 'pkg_a', "unique model resolves to pkg_a") }}
+
+    {% set unique_scoped = audit_helper_ext.get_model_node('pkg_unique_model', package_name='pkg_a') %}
+    {{ assert_equal(
+        unique_scoped.package_name, 'pkg_a', "unique model resolves with explicit package_name") }}
+
+    {% set unique_wrong = audit_helper_ext.get_model_node('pkg_unique_model', package_name='audit_helper_ext_test') %}
+    {{ assert_equal(
+        unique_wrong.name, 'undefined', "unique model not found in the wrong package") }}
+
+    {% set dup_node = audit_helper_ext.get_model_node('pkg_dup_model') %}
+    {{ assert_equal(
+        dup_node.name, 'pkg_dup_model', "duplicate model resolves to a real node without a hint") }}
+
+    {% set dup_pkg_a = audit_helper_ext.get_model_node('pkg_dup_model', package_name='pkg_a') %}
+    {{ assert_equal(
+        dup_pkg_a.package_name, 'pkg_a', "duplicate model disambiguates to pkg_a") }}
+
+    {% set dup_root = audit_helper_ext.get_model_node('pkg_dup_model', package_name='audit_helper_ext_test') %}
+    {{ assert_equal(
+        dup_root.package_name, 'audit_helper_ext_test', "duplicate model disambiguates to the root project") }}
+
+    {% set lineage_pkg_a = audit_helper_ext.get_upstream_lineage('pkg_dup_model', package_name='pkg_a') %}
+    {{ assert_equal(
+        lineage_pkg_a | length > 0, true, "lineage resolves the pkg_a duplicate") }}
+    {{ assert_equal(
+        lineage_pkg_a[0][0].name, 'pkg_dup_model', "lineage root node is pkg_dup_model") }}
+
+    {% set lineage_root = audit_helper_ext.get_upstream_lineage('pkg_dup_model', package_name='audit_helper_ext_test') %}
+    {{ assert_equal(
+        lineage_root[0][0].name, 'pkg_dup_model', "lineage resolves the root duplicate") }}
+
+    {% set lineage_ambiguous = audit_helper_ext.get_upstream_lineage('pkg_dup_model') %}
+    {{ assert_equal(
+        lineage_ambiguous | length > 0, true, "lineage resolves an ambiguous duplicate without a hint") }}
+
+    {% set lineage_missing = audit_helper_ext.get_upstream_lineage('pkg_dup_model', package_name='does_not_exist') %}
+    {{ assert_equal(
+        lineage_missing | length, 0, "lineage returns empty for an unknown package") }}
+
+    {% set src_ambiguous = audit_helper_ext.get_source_node('pkg_shared_source', 'pkg_dup_table') %}
+    {{ assert_equal(
+        src_ambiguous.name, 'pkg_dup_table', "duplicate source resolves to a real node without a hint") }}
+
+    {% set src_pkg_a = audit_helper_ext.get_source_node('pkg_shared_source', 'pkg_dup_table', package_name='pkg_a') %}
+    {{ assert_equal(
+        src_pkg_a.package_name, 'pkg_a', "duplicate source disambiguates to pkg_a") }}
+
+    {% set src_root = audit_helper_ext.get_source_node('pkg_shared_source', 'pkg_dup_table', package_name='audit_helper_ext_test') %}
+    {{ assert_equal(
+        src_root.package_name, 'audit_helper_ext_test', "duplicate source disambiguates to the root project") }}
+
+    {% set src_missing = audit_helper_ext.get_source_node('pkg_shared_source', 'pkg_dup_table', package_name='does_not_exist') %}
+    {{ assert_equal(
+        src_missing.name, 'undefined', "source not found in an unknown package") }}
+
+    {% set _, rel_pkg_a, _ = audit_helper_ext.get_relation('pkg_dup_model', package_name='pkg_a') %}
+    {{ assert_equal(
+        rel_pkg_a.identifier, 'pkg_dup_model', "get_relation resolves the pkg_a duplicate model") }}
+
+    {{ log("🎉 test__package_scoped_lookup: all assertions passed.", info=true) }}
+
+{% endmacro %}

--- a/integration_tests/models/pkg_dup_model.sql
+++ b/integration_tests/models/pkg_dup_model.sql
@@ -1,0 +1,2 @@
+{{ config(materialized='ephemeral') }}
+select 1 as id, 'audit_helper_ext_test' as owner_package

--- a/integration_tests/models/pkg_dup_source.yml
+++ b/integration_tests/models/pkg_dup_source.yml
@@ -1,0 +1,5 @@
+sources:
+  - name: pkg_shared_source
+    schema: audit_helper_ext_seed
+    tables:
+      - name: pkg_dup_table

--- a/integration_tests/package-lock.yml
+++ b/integration_tests/package-lock.yml
@@ -1,7 +1,12 @@
 packages:
   - local: ../
-  - package: dbt-labs/dbt_utils
-    version: 1.3.0
-  - package: dbt-labs/audit_helper
-    version: 0.12.0
-sha1_hash: de2deba3d66ce03d8c02949013650cc9b94f6030
+    name: audit_helper_ext
+  - local: test_packages/pkg_a
+    name: pkg_a
+  - name: dbt_utils
+    package: dbt-labs/dbt_utils
+    version: 1.4.1
+  - name: audit_helper
+    package: dbt-labs/audit_helper
+    version: 0.14.0
+sha1_hash: 53c0f844e57b514f5f81d78896eee404eff952fd

--- a/integration_tests/packages.yml
+++ b/integration_tests/packages.yml
@@ -1,2 +1,3 @@
 packages:
   - local: ../
+  - local: test_packages/pkg_a

--- a/integration_tests/test_packages/pkg_a/dbt_project.yml
+++ b/integration_tests/test_packages/pkg_a/dbt_project.yml
@@ -1,0 +1,9 @@
+name: pkg_a
+version: '0.0.0'
+config-version: 2
+
+model-paths: ["models"]
+
+models:
+  pkg_a:
+    +materialized: ephemeral

--- a/integration_tests/test_packages/pkg_a/models/pkg_dup_model.sql
+++ b/integration_tests/test_packages/pkg_a/models/pkg_dup_model.sql
@@ -1,0 +1,2 @@
+{{ config(alias='pkg_dup_model__pkg_a') }}
+select 1 as id, 'pkg_a' as owner_package

--- a/integration_tests/test_packages/pkg_a/models/pkg_dup_source.yml
+++ b/integration_tests/test_packages/pkg_a/models/pkg_dup_source.yml
@@ -1,0 +1,5 @@
+sources:
+  - name: pkg_shared_source
+    schema: audit_helper_ext_seed
+    tables:
+      - name: pkg_dup_table

--- a/integration_tests/test_packages/pkg_a/models/pkg_unique_model.sql
+++ b/integration_tests/test_packages/pkg_a/models/pkg_unique_model.sql
@@ -1,0 +1,1 @@
+select 1 as id

--- a/macros/dwh/clone_relation.sql
+++ b/macros/dwh/clone_relation.sql
@@ -1,15 +1,16 @@
-{% macro clone_relation(identifier, source_database=none, source_schema=none, source_name=none, use_prev=false) %}
+{% macro clone_relation(identifier, source_database=none, source_schema=none, source_name=none, use_prev=false, package_name=none) %}
     {{ return(adapter.dispatch('clone_relation', 'audit_helper_ext')(
         identifier=identifier,
         source_database=source_database,
         source_schema=source_schema,
         source_name=source_name,
-        use_prev=use_prev
+        use_prev=use_prev,
+        package_name=package_name
     )) }}
 {% endmacro %}
 
 
-{% macro default__clone_relation(identifier, source_database, source_schema, source_name, use_prev) %}
+{% macro default__clone_relation(identifier, source_database, source_schema, source_name, use_prev, package_name) %}
     {% set copy_mode = 'clone' %}
 
     {# Resolve source_identifier using naming convention #}
@@ -28,7 +29,8 @@
     {% set source_relation_exists, source_relation, _ = audit_helper_ext.get_relation(
         identifier=source_identifier,
         identifier_database=source_database,
-        identifier_schema=source_schema
+        identifier_schema=source_schema,
+        package_name=package_name
     ) %}
     {% if source_relation_exists == false %}
         {% do exceptions.raise_compiler_error("❌ The table " ~ source_relation.identifier ~ " cannot be found at " ~  source_relation ~ "." ) %}
@@ -40,7 +42,8 @@
     {# checking target table #}
     {% set dbt_relation_exists, dbt_relation, dbt_config = audit_helper_ext.get_relation(
         identifier=identifier,
-        source_name=source_name
+        source_name=source_name,
+        package_name=package_name
     ) %}
     {% if dbt_relation_exists == true and dbt_relation.type == 'view' %}
         {{ log("ℹ️ 🗑️  " ~ dbt_relation.identifier ~ " exists as a view, it needs to be dropped first.", true) }}

--- a/macros/dwh/clone_relation_extended.sql
+++ b/macros/dwh/clone_relation_extended.sql
@@ -1,4 +1,4 @@
-{% macro clone_relation_extended(identifiers, source_database=none, source_schema=none, dependant_table_names=none, tag=none, use_prev=true, exclude_identifiers=none) %}
+{% macro clone_relation_extended(identifiers, source_database=none, source_schema=none, dependant_table_names=none, tag=none, use_prev=true, exclude_identifiers=none, package_name=none) %}
     {{ return(adapter.dispatch('clone_relation_extended', 'audit_helper_ext')(
         identifiers=identifiers,
         source_database=source_database,
@@ -6,12 +6,13 @@
         dependant_table_names=dependant_table_names,
         tag=tag,
         use_prev=use_prev,
-        exclude_identifiers=exclude_identifiers
+        exclude_identifiers=exclude_identifiers,
+        package_name=package_name
     )) }}
 {% endmacro %}
 
 
-{% macro default__clone_relation_extended(identifiers, source_database, source_schema, dependant_table_names, tag, use_prev, exclude_identifiers) %}
+{% macro default__clone_relation_extended(identifiers, source_database, source_schema, dependant_table_names, tag, use_prev, exclude_identifiers, package_name) %}
 
     {% if execute %}
         {# -- Parse comma-separated identifiers into a list -- #}
@@ -28,7 +29,8 @@
                     identifier=id,
                     source_database=source_database,
                     source_schema=source_schema,
-                    use_prev=use_prev
+                    use_prev=use_prev,
+                    package_name=package_name
                 ) %}
             {% endif %}
         {% endfor %}
@@ -37,7 +39,8 @@
         {% set all_sources = audit_helper_ext.get_dependent_source_nodes(
             identifiers=identifiers,
             dependant_table_names=dependant_table_names,
-            tag=tag
+            tag=tag,
+            package_name=package_name
         ) %}
 
         {% set sources_to_clone = audit_helper_ext.filter_source_exclusions(all_sources, identifiers=identifiers, exclude_identifiers=exclude_identifiers) %}

--- a/macros/relation/filter_nodes_by_package.sql
+++ b/macros/relation/filter_nodes_by_package.sql
@@ -1,0 +1,31 @@
+{% macro filter_nodes_by_package(nodes, package_name, identifier) %}
+  {{ return(adapter.dispatch('filter_nodes_by_package', 'audit_helper_ext')(
+      nodes=nodes,
+      package_name=package_name,
+      identifier=identifier
+  )) }}
+{% endmacro %}
+
+
+{% macro default__filter_nodes_by_package(nodes, package_name, identifier) %}
+
+    {% set matched = [] %}
+    {% for node in nodes %}
+        {% if package_name is none or node.package_name == package_name %}
+            {% do matched.append(node) %}
+        {% endif %}
+    {% endfor %}
+
+    {% if matched | length > 1 %}
+        {% set entity_label = matched[0].unique_id.split('.')[0] | capitalize %}
+        {{ log(
+            "⚠️  " ~ entity_label ~ " '" ~ identifier ~ "' matched " ~ matched | length
+            ~ " nodes across packages [" ~ (matched | map(attribute='package_name') | join(', '))
+            ~ "]. Selecting the first ('" ~ matched[0].package_name
+            ~ "'). Pass package_name to disambiguate.", info=true)
+        }}
+    {% endif %}
+
+    {{ return(matched) }}
+
+{% endmacro %}

--- a/macros/relation/filter_nodes_by_package.yml
+++ b/macros/relation/filter_nodes_by_package.yml
@@ -1,0 +1,11 @@
+macros:
+  - name: filter_nodes_by_package
+    description: |
+        Filter a list of graph nodes to those in a given package.
+
+        When `package_name` is none, all nodes pass through. When more than one
+        node survives the filter, an ambiguity warning is logged (naming the
+        matched packages and the one that will be selected first) so callers can
+        pick a single node deterministically while nudging the user to pass
+        `package_name`. The entity label in that warning ("Model", "Source", ...)
+        is derived from the node's `unique_id`, so callers do not pass it in.

--- a/macros/relation/get_model_node.sql
+++ b/macros/relation/get_model_node.sql
@@ -1,19 +1,22 @@
-{% macro get_model_node(identifier) %}
-  {{ return(adapter.dispatch('get_model_node', 'audit_helper_ext')(identifier=identifier)) }}
+{% macro get_model_node(identifier, package_name=none) %}
+  {{ return(adapter.dispatch('get_model_node', 'audit_helper_ext')(identifier=identifier, package_name=package_name)) }}
 {% endmacro %}
 
 
-{% macro default__get_model_node(identifier) %}
+{% macro default__get_model_node(identifier, package_name) %}
+
+    {% set candidates = graph.nodes.values()
+        | selectattr("resource_type", "equalto", "model")
+        | selectattr("name", "equalto", identifier | trim)
+        | list %}
 
     {% set ns = namespace() %}
-    {% set ns.node = [] %}
-    {% for node in graph.nodes.values()
-        | selectattr("resource_type", "equalto", "model")
-        | selectattr("package_name", "equalto", project_name)
-        | selectattr("name", "equalto", identifier | trim)
-    %}
-        {% do ns.node.append(node) %}
-    {% endfor -%}
+    {% set ns.node = audit_helper_ext.filter_nodes_by_package(
+        candidates,
+        package_name=package_name,
+        identifier=identifier | trim
+    ) %}
+
     {% if ns.node | length > 0 %}
         {% set first_node = ns.node[0] %}
     {% else %}

--- a/macros/relation/get_relation.sql
+++ b/macros/relation/get_relation.sql
@@ -1,20 +1,21 @@
-{% macro get_relation(identifier, identifier_database=none, identifier_schema=none, node_name=none, source_name=none) %}
+{% macro get_relation(identifier, identifier_database=none, identifier_schema=none, node_name=none, source_name=none, package_name=none) %}
   {% set node_name = node_name or identifier %}
   {{ return(adapter.dispatch('get_relation', 'audit_helper_ext')(
       identifier=identifier,
       identifier_database=identifier_database,
       identifier_schema=identifier_schema,
       node_name=node_name,
-      source_name=source_name
+      source_name=source_name,
+      package_name=package_name
   )) }}
 {% endmacro %}
 
 
-{% macro default__get_relation(identifier, identifier_database, identifier_schema, node_name, source_name) %}
+{% macro default__get_relation(identifier, identifier_database, identifier_schema, node_name, source_name, package_name) %}
 
-    {% set node = audit_helper_ext.get_model_node(node_name) %}
+    {% set node = audit_helper_ext.get_model_node(node_name, package_name=package_name) %}
     {% if node.name == 'undefined' and source_name %}
-        {% set node = audit_helper_ext.get_source_node(source_name=source_name, identifier=node_name) %}
+        {% set node = audit_helper_ext.get_source_node(source_name=source_name, identifier=node_name, package_name=package_name) %}
     {% endif %}
 
     {% set database = identifier_database or node.database %}

--- a/macros/relation/get_source_node.sql
+++ b/macros/relation/get_source_node.sql
@@ -1,18 +1,22 @@
-{% macro get_source_node(source_name, identifier) %}
-  {{ return(adapter.dispatch('get_source_node', 'audit_helper_ext')(source_name=source_name, identifier=identifier)) }}
+{% macro get_source_node(source_name, identifier, package_name=none) %}
+  {{ return(adapter.dispatch('get_source_node', 'audit_helper_ext')(source_name=source_name, identifier=identifier, package_name=package_name)) }}
 {% endmacro %}
 
 
-{% macro default__get_source_node(source_name, identifier) %}
+{% macro default__get_source_node(source_name, identifier, package_name) %}
 
-    {% set ns = namespace() %}
-    {% set ns.node = [] %}
-    {% for node in graph.sources.values()
+    {% set candidates = graph.sources.values()
         | selectattr("source_name", "equalto", source_name | trim)
         | selectattr("name", "equalto", identifier | trim)
-    %}
-        {% do ns.node.append(node) %}
-    {% endfor -%}
+        | list %}
+
+    {% set ns = namespace() %}
+    {% set ns.node = audit_helper_ext.filter_nodes_by_package(
+        candidates,
+        package_name=package_name,
+        identifier=source_name | trim ~ ':' ~ identifier | trim
+    ) %}
+
     {% if ns.node | length > 0 %}
         {% set first_node = ns.node[0] %}
     {% else %}

--- a/macros/utility/lineage/get_dependent_source_nodes.sql
+++ b/macros/utility/lineage/get_dependent_source_nodes.sql
@@ -1,13 +1,14 @@
-{% macro get_dependent_source_nodes(identifiers, dependant_table_names=none, tag=none) %}
+{% macro get_dependent_source_nodes(identifiers, dependant_table_names=none, tag=none, package_name=none) %}
     {{ return(adapter.dispatch('get_dependent_source_nodes', 'audit_helper_ext')(
         identifiers=identifiers,
         dependant_table_names=dependant_table_names,
-        tag=tag
+        tag=tag,
+        package_name=package_name
     )) }}
 {% endmacro %}
 
 
-{% macro default__get_dependent_source_nodes(identifiers, dependant_table_names, tag) %}
+{% macro default__get_dependent_source_nodes(identifiers, dependant_table_names, tag, package_name) %}
 
     {# -- Parse comma-separated inputs into lists -- #}
     {% set identifier_list = identifiers.split(',') | map('trim') | select | list %}
@@ -18,7 +19,7 @@
     {% for identifier in identifier_list %}
 
         {# -- Get target model node -- #}
-        {% set target_node = audit_helper_ext.get_model_node(identifier) %}
+        {% set target_node = audit_helper_ext.get_model_node(identifier, package_name=package_name) %}
         {% if target_node.name == 'undefined' %}
             {% do exceptions.raise_compiler_error(
                 "❌ Model '" ~ identifier ~ "' not found in the dbt graph."
@@ -26,7 +27,7 @@
         {% endif %}
 
         {# -- Collect upstream models (including target) from lineage paths -- #}
-        {% set lineage_paths = audit_helper_ext.get_upstream_lineage(identifier) %}
+        {% set lineage_paths = audit_helper_ext.get_upstream_lineage(identifier, package_name=package_name) %}
 
         {% for path in lineage_paths %}
             {% for node_info in path %}

--- a/macros/utility/lineage/get_upstream_lineage.sql
+++ b/macros/utility/lineage/get_upstream_lineage.sql
@@ -1,17 +1,26 @@
-{% macro get_upstream_lineage(dbt_identifier) %}
-  {{ return(adapter.dispatch('get_upstream_lineage', 'audit_helper_ext')(dbt_identifier=dbt_identifier)) }}
+{% macro get_upstream_lineage(dbt_identifier, package_name=none) %}
+  {{ return(adapter.dispatch('get_upstream_lineage', 'audit_helper_ext')(dbt_identifier=dbt_identifier, package_name=package_name)) }}
 {% endmacro %}
 
 
-{% macro default__get_upstream_lineage(dbt_identifier) %}
+{% macro default__get_upstream_lineage(dbt_identifier, package_name) %}
   {% if execute %}
 
     {# Get the node for this model #}
-    {% set dbt_node = graph.nodes.values() | selectattr("name", "equalto", dbt_identifier) | first %}
+    {% set candidates = graph.nodes.values()
+        | selectattr("name", "equalto", dbt_identifier)
+        | list %}
+    {% set matched_nodes = audit_helper_ext.filter_nodes_by_package(
+        candidates,
+        package_name=package_name,
+        identifier=dbt_identifier
+    ) %}
 
-    {% if not dbt_node %}
+    {% if matched_nodes | length == 0 %}
       {{ return([]) }}
     {% endif %}
+
+    {% set dbt_node = matched_nodes[0] %}
 
     {# Initialize data structures for traversal #}
     {% set lineage_paths = [] %}

--- a/macros/validation/get_validation_full.sql
+++ b/macros/validation/get_validation_full.sql
@@ -5,7 +5,8 @@
     old_identifier,
     primary_keys,
     exclude_columns=[],
-    summarize=true
+    summarize=true,
+    package_name=none
 ) %}
   {{ return(adapter.dispatch('get_validation_full', 'audit_helper_ext')
       (
@@ -15,7 +16,8 @@
         old_identifier=old_identifier,
         primary_keys=primary_keys,
         exclude_columns=exclude_columns,
-        summarize=summarize
+        summarize=summarize,
+        package_name=package_name
       )
   ) }}
 {% endmacro %}
@@ -28,7 +30,8 @@
     old_identifier,
     primary_keys,
     exclude_columns=[],
-    summarize=true
+    summarize=true,
+    package_name=none
 ) %}
 
     {% set old_relation = adapter.get_relation(
@@ -69,7 +72,7 @@
           {% endif %}
 
           {# Print lineage information #}
-          {% set lineage_paths = audit_helper_ext.get_upstream_lineage(dbt_identifier) %}
+          {% set lineage_paths = audit_helper_ext.get_upstream_lineage(dbt_identifier, package_name=package_name) %}
           {% set lineage_output = audit_helper_ext.format_lineage(lineage_paths) %}
             {{ log('💡 Upstream Lineage:', true) }}
           {{ audit_helper_ext.log_debug(lineage_output) }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,9 @@ validate-supplies = [
 validate--disable-print-table = [
   {shell = "cd integration_tests && dbt run-operation validation_count__sample_1 --vars '{audit_helper__print_table_enabled: no}'"}
 ]
+validate-package-lookup = [
+  {shell = "cd integration_tests && dbt run-operation test__package_scoped_lookup"}
+]
 validate--pg-single-max-parallel = [
   {shell = "cd integration_tests && dbt run-operation validation_count__sample_1 --vars '{audit_helper__audit_query_pre_hooks: [\"SET max_parallel_workers_per_gather = 1\"]}' --profiles-dir dev/postgres --target pg"}
 ]
@@ -204,6 +207,7 @@ validate = [
   {cmd = "poe validate-stores"},
   {cmd = "poe validate-supplies"},
   {cmd = "poe validate--disable-print-table"},
+  {cmd = "poe validate-package-lookup"},
 ]
 validate-sf = { env = { DBT_PROFILES_DIR = "dev/snowflake", DBT_TARGET = "sf" }, cmd = "poe validate" }
 validate-adb = { env = { DBT_PROFILES_DIR = "dev/databricks", DBT_TARGET = "adb" }, cmd = "poe validate" }


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
resolves #

This is a:

- [ ] documentation update
- [ ] bug fix with no breaking changes
- [x] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation

Adds package-scoped node lookup so models/sources sharing a name across packages can be disambiguated.

- New `filter_nodes_by_package` macro filters candidate nodes by `package_name`; warns and selects the first match on cross-package collisions.
- Threads an optional `package_name` argument through `get_model_node`, `get_source_node`, `get_relation`, and `get_upstream_lineage`.
- Adds integration test fixtures (`pkg_a`) and `test__package_scoped_lookup` coverage.

## Checklist

- [ ] This code is associated with an Issue which has been triaged and accepted for development
- [x] I have verified that these changes work locally on the following warehouses:
  - [x] Snowflake
  - [ ] BigQuery
  - [ ] SQLServer
  - [ ] PostgreSQL
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
