### PR TITLE
fix(clone): pass package_name when cloning dependent source nodes

### DIFF
--- a/macros/dwh/clone_relation_extended.sql
+++ b/macros/dwh/clone_relation_extended.sql
@@ -66,7 +66,8 @@
                 source_database=source_node.database,
                 source_schema=versioned_schema,
                 source_name=source_node.source_name,
-                use_prev=false
+                use_prev=false,
+                package_name=source_node.package_name
             ) %}
         {% endfor %}
 


### PR DESCRIPTION
resolves #

This is a:

- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation

The dependent-source clone loop in `clone_relation_extended` called `clone_relation` without `package_name`, so `get_source_node` -> `filter_nodes_by_package` resolved with `package_name=none`. When a source identifier is defined in multiple packages (e.g. `edwload_dim:DATE_DIM`), this triggered the "matched N nodes across packages" warning and silently selected the first package — even when the caller passed `package_name`.

Fix: thread each source node's own `package_name` into the clone call so every dependent source resolves to its correct package.

## Checklist

- [ ] This code is associated with an Issue which has been triaged and accepted for development
- [x] I have verified that these changes work locally on the following warehouses:
  - [x] Snowflake
  - [ ] BigQuery
  - [ ] SQLServer
  - [ ] PostgreSQL
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
