### PR TITLE
fix: DuckDB validation_log_report returns NULL relation_row_count

### DIFF
--- a/integration_tests/tests/verify_validation_log_report__counts.sql
+++ b/integration_tests/tests/verify_validation_log_report__counts.sql
@@ -1,0 +1,12 @@
+-- Integration test: verify validation_log_report populates count/match fields
+-- correctly after validation macros run, on all adapters.
+-- Empty result = PASS.
+
+select *
+from {{ ref('validation_log_report') }}
+where mart_table = 'sample_1'
+  and (
+    old_relation_row_count is null
+    or dbt_relation_row_count is null
+    or match_count is null
+  )

--- a/macros/sql/general/json_field_sql.sql
+++ b/macros/sql/general/json_field_sql.sql
@@ -42,7 +42,7 @@
 {% macro duckdb__json_field_sql(json_table_alias, json_field) %}
 
   {% set sql -%}
-    ({{ json_table_alias }}->>'{{ json_field }}')
+    ({{ json_table_alias }}.unnest->>'{{ json_field }}')
   {%- endset %}
 
   {{ return(sql) }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,7 @@ validate = [
   {cmd = "poe validate-stores"},
   {cmd = "poe validate-supplies"},
   {cmd = "poe validate--disable-print-table"},
+  {shell = "cd integration_tests && dbt test -s verify_validation_log_report__counts"},
 ]
 validate-sf = { env = { DBT_PROFILES_DIR = "dev/snowflake", DBT_TARGET = "sf" }, cmd = "poe validate" }
 validate-adb = { env = { DBT_PROFILES_DIR = "dev/databricks", DBT_TARGET = "adb" }, cmd = "poe validate" }


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->
resolves #64

This is a:

- [ ] documentation update
- [x] bug fix with no breaking changes
- [ ] new functionality
- [ ] a breaking change

All pull requests from community contributors should target the `main` branch (default).

## Description & motivation
Fix #64 , as mention in the issue, DuckDB returns a table from unnest(from_json(...)) with a single column named unnest. The JSON object is inside result.unnest, not result itself.

<img width="1054" height="564" alt="image" src="https://github.com/user-attachments/assets/903562f6-900f-489d-a961-713ceaedd8e4" />


---
Not sure about the CI part but look like the test won’t run during poe build because poe build excludes the audit_helper_ext package, so I added the test as the last step of the validate task. Modified it if you see it need a change here


## Checklist

- [ ] This code is associated with an Issue which has been triaged and accepted for development
- [ ] I have verified that these changes work locally on the following warehouses:
  - [ ] Snowflake
  - [ ] BigQuery
  - [ ] SQLServer
  - [ ] PostgreSQL
  - [x] DuckDB
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
